### PR TITLE
Remove CDVWKWebViewEngine

### DIFF
--- a/src/config.xml.mustache
+++ b/src/config.xml.mustache
@@ -111,15 +111,6 @@
         <!-- Disable backup to iCloud on iOS. -->
         <preference name="BackupWebStorage" value="none" />
 
-        <plugin name="cordova-plugin-wkwebview-engine-mx" source="npm" spec="1.0.1-mx.1.2.1" />
-
-        <!-- Enable WKWebView on iOS -->
-        <feature name="CDVWKWebViewEngine">
-            <param name="ios-package" value="CDVWKWebViewEngine" />
-        </feature>
-
-        <preference name="CordovaWebViewEngine" value="CDVWKWebViewEngine" />
-
         <preference name="KeyboardDisplayRequiresUserAction" value="false" />
 
         <platform name="ios">


### PR DESCRIPTION
CDVWKWebViewEngine introduces CORS which can't be mitigated at the moment. 
As a fix removing it for now till we have an efficient solution to support CORS correctly.